### PR TITLE
Updating wording of Rate Limiting section

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -41,7 +41,9 @@ API keys are used as Authorization tokens in the header in all authenticated API
 SSO is also available via our Integrations and via SAML 2.0.
 
 # Rate Limiting
-We allow up to 200 requests every 30 seconds from a single IP address. If you attempt to make requests more quickly then this you may receive a `429 Too Many Requests` response from an endpoint.
+We allow up to 2000 requests every 5 minutes from a single IP address, but some higher security endpoints have stricter rate limiting. Requests are counted in 30 second periods.
+
+If you attempt to make requests more quickly than permitted by these rules, you may receive a `429 Too Many Requests` response from an endpoint.
 
 # Errors
 Accredible uses conventional HTTP response codes to indicate the success or failure of an API request. Codes in the 2xx range indicate success in general and codes in the 4xx range indicate an error that failed given the information provided (e.g., a required parameter was omitted, a permissions error, etc). Codes in the 5xx range indicate an error with Accredible.


### PR DESCRIPTION
Following the changes made in [DVO-98](https://accredible.atlassian.net/browse/DVO-98), we missed updating this part of our Apiary docs to be more accurate.

I have changed the wording to be more true to how our WAF implementation works. 

[DVO-98]: https://accredible.atlassian.net/browse/DVO-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ