### PR TITLE
Add department_id to search attribute keys EP docs

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2222,6 +2222,7 @@ You can search for Attribute Keys by various search criteria.
 + Parameters
     + name (string, optional) - A name for the custom attribute key.
     + kind (string, optional) - The kind of custom attribute key. Must be one of the following - [text, date, email, image]
+    + department_id (id, optional) - Only return attributes within the given department.
     + page_size(number, optional) - The pagination response size, default of 50.
     + page(number,optional) - The pagination page.
 
@@ -2235,7 +2236,8 @@ You can search for Attribute Keys by various search criteria.
 
             {
                 "name": "attribute",
-                "kind": "text"
+                "kind": "text",
+                "department_id": 123
             }
 
 + Response 200 (application/json)


### PR DESCRIPTION
[ACMS-4617](https://accredible.atlassian.net/browse/ACMS-4617): The department_id param is [already in place](https://github.com/accredible/accredible-credential-api/blob/develop/app/controllers/api/v1/public_api/attribute_keys_controller.rb#L30), it's just missing from the docs. This PR to add it to the docs, so customers know how to use it. 

[ACMS-4617]: https://accredible.atlassian.net/browse/ACMS-4617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ