### PR TITLE
DGR-364 - BE - Support custom attributes search in the V2 credential search Endpoint

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -995,7 +995,7 @@ Following operations will be **supported based on the field**. You can also comb
         + meta_data (object, optional) - String key/values for client's own data on the credential.
         Supported operations - none
         + custom_attributes (object, optional) - String key/values for client's own data on the credential.
-        Supported operations - `eq`
+        Supported operations - none
         + issued_on (string, optional) - Date on which the credentials have been issued. Format: YYYY-MM-DD
         Supported operations - `eq`, `in`, `lt`, `lte`, `gt`, `gte`
         + expired_on (string, optional) - Date on which the credentials will expire. Format: YYYY-MM-DD

--- a/apiary.apib
+++ b/apiary.apib
@@ -994,6 +994,8 @@ Following operations will be **supported based on the field**. You can also comb
         Supported operations - `eq`, `in`
         + meta_data (object, optional) - String key/values for client's own data on the credential.
         Supported operations - none
+        + custom_attibutes (object, optional) - String key/values for client's own data on the credential.
+        Supported operations - `eq`
         + issued_on (string, optional) - Date on which the credentials have been issued. Format: YYYY-MM-DD
         Supported operations - `eq`, `in`, `lt`, `lte`, `gt`, `gte`
         + expired_on (string, optional) - Date on which the credentials will expire. Format: YYYY-MM-DD

--- a/apiary.apib
+++ b/apiary.apib
@@ -994,7 +994,7 @@ Following operations will be **supported based on the field**. You can also comb
         Supported operations - `eq`, `in`
         + meta_data (object, optional) - String key/values for client's own data on the credential.
         Supported operations - none
-        + custom_attibutes (object, optional) - String key/values for client's own data on the credential.
+        + custom_attributes (object, optional) - String key/values for client's own data on the credential.
         Supported operations - `eq`
         + issued_on (string, optional) - Date on which the credentials have been issued. Format: YYYY-MM-DD
         Supported operations - `eq`, `in`, `lt`, `lte`, `gt`, `gte`


### PR DESCRIPTION
[DGR-364] Added custom attributes search functionality to documentation (https://accredible.atlassian.net/browse/DGR-364)
Custom Attributes already exists for public API, just wasn't added to the documentation  

[DGR-364]: https://accredible.atlassian.net/browse/DGR-364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

**Documentation**
<img width="717" alt="Screenshot 2024-05-09 at 10 28 50" src="https://github.com/accredible/api-documentation/assets/16685932/a2b8663d-f87b-4f94-a0d2-ef13c85bd331">

**Request Body**
<img width="489" alt="Screenshot 2024-05-09 at 10 45 32" src="https://github.com/accredible/api-documentation/assets/16685932/08ed5b27-1280-41a7-aaf5-3f5b03454f54">

**Response Body**
<img width="505" alt="Screenshot 2024-05-09 at 10 44 25" src="https://github.com/accredible/api-documentation/assets/16685932/c084b631-5150-436c-96cf-16f27af28fdf">

