### PR TITLE
DGR-464-BE-Add the additional attributes to Apiary

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1456,11 +1456,11 @@ For example you should create a group for the Introduction to Programming course
         + meta_data (object, optional) - You can use this parameter to attach key-value strings to the object. Meta data is useful for storing additional, structured information on an object.
         + learning_outcomes(array, optional) - Searchable keywords identifying skills credential-holders need to demonstrate (or have learned) in the process of earning this credential.
         + generate_private_credential (boolean, optional) - The default value of `Credential.private` for the Group. The supported values are `true`, `false`, and `null`. When this is set to `true` or `false`, it will override `Department.generate_private_credential` and be used as the default of `Credential.private` when creating a new `Credential`. When this is set to `null`, it won't override `Department.generate_private_credential` which will be used for the default of `Credential.private` instead.
-        + auto_expiry (number, optional) - If the Group's credentials expire, it's important to set an expiration period. Add a number to say how long the credentials for this group should be valid. e.g. 1 means expires in 1 year.
+        + auto_expiry (number, optional) - Set a date for when the credentials automatically expire after a certain amount of time has elapsed since the date of issue.
+        + signup_url (string, optional) - This provides a direct path for credential viewers to enroll in your course.
         + signup_url_show (boolean, optional) - Show or hide the sign up url. The supported values are `true`, `false` and `null`.
-        + signup_url (string, optional) - This provides a direct path for credential viewers in the Group to enrol on your course.
-        + course_link_show (boolean, optional) - You can use this parameter to show or hide the page on your website specifically regarding the course the credential was issued for. The supported values are `true`, `false` and `null`
-        + organization_link_show (boolean, optional) - You can use this parameter to show or hide the link to your website homepage. The supported values are `true`, `false` and `null`
+        + course_link_show (boolean, optional) - This links the credential data record to your information about the credential on your website. The supported values are `true`, `false` and `null`.
+        + organization_link_show (boolean, optional) - Show or hide the link to your website homepage. The supported values are `true`, `false` and `null`.
 
     + Body
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -1593,11 +1593,11 @@ For example you should create a group for the Introduction to Programming course
         + meta_data (object, optional) - You can use this parameter to attach key-value strings to the object. Meta data is useful for storing additional, structured information on an object.
         + learning_outcomes(array, optional) - Searchable keywords identifying skills credential-holders need to demonstrate (or have learned) in the process of earning this credential.
         + generate_private_credential (boolean, optional) - The default value of `Credential.private` for the Group. The supported values are `true`, `false`, and `null`. When this is set to `true` or `false`, it will override `Department.generate_private_credential` and be used as the default of `Credential.private` when creating a new `Credential`. When this is set to `null`, it won't override `Department.generate_private_credential` which will be used for the default of `Credential.private` instead.
-        + auto_expiry (number, optional) - If the Group's credentials expire, it's important to set an expiration period. Add a number to say how long the credentials for this group should be valid. e.g. 1 means expires in 1 year.
+        + auto_expiry (number, optional) - Set a date for when the credentials automatically expire after a certain amount of time has elapsed since the date of issue.
+        + signup_url (string, optional) - This provides a direct path for credential viewers to enroll in your course.
         + signup_url_show (boolean, optional) - Show or hide the sign up url. The supported values are `true`, `false` and `null`.
-        + signup_url (string, optional) - This provides a direct path for credential viewers in the Group to enrol on your course.
-        + course_link_show (boolean, optional) - You can use this parameter to show or hide the page on your website specifically regarding the course the credential was issued for. The supported values are `true`, `false` and `null`
-        + organization_link_show (boolean, optional) - You can use this parameter to show or hide the link to your website homepage. The supported values are `true`, `false` and `null`
+        + course_link_show (boolean, optional) - This links the credential data record to your information about the credential on your website. The supported values are `true`, `false` and `null`.
+        + organization_link_show (boolean, optional) - Show or hide the link to your website homepage. The supported values are `true`, `false` and `null`.
 
     + Body
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -1484,7 +1484,7 @@ For example you should create a group for the Introduction to Programming course
                     "generate_private_credential": false,
                     "auto_expiry": 1,
                     "signup_url_show": false,
-                    "signup_url": "https://example.com",
+                    "signup_url": "http://www.example.com",
                     "course_link_show": false,
                     "organization_link_show": false
                 }
@@ -1518,7 +1518,7 @@ For example you should create a group for the Introduction to Programming course
                 "generate_private_credential": false,
                 "auto_expiry": 1,
                 "signup_url_show": false,
-                "signup_url": "https://example.com",
+                "signup_url": "http://www.example.com",
                 "course_link_show": false,
                 "organization_link_show": false
             }
@@ -1560,7 +1560,7 @@ For example you should create a group for the Introduction to Programming course
             "generate_private_credential": false,
             "auto_expiry": 1,
             "signup_url_show": false,
-            "signup_url": "https://example.com",
+            "signup_url": "http://www.example.com",
             "course_link_show": false,
             "organization_link_show": false
           }
@@ -1634,7 +1634,7 @@ For example you should create a group for the Introduction to Programming course
             "generate_private_credential": false,
             "auto_expiry": 1,
             "signup_url_show": false,
-            "signup_url": "https://example.com",
+            "signup_url": "http://www.example.com",
             "course_link_show": false,
             "organization_link_show": false
           }
@@ -1675,7 +1675,7 @@ For example you should create a group for the Introduction to Programming course
             "generate_private_credential": false,
             "auto_expiry": 1,
             "signup_url_show": false,
-            "signup_url": "https://example.com",
+            "signup_url": "http://www.example.com",
             "course_link_show": false,
             "organization_link_show": false
             }
@@ -1724,7 +1724,7 @@ For example you should create a group for the Introduction to Programming course
                     "generate_private_credential": false,
                     "auto_expiry": 1,
                     "signup_url_show": false,
-                    "signup_url": "https://example.com",
+                    "signup_url": "http://www.example.com",
                     "course_link_show": false,
                     "organization_link_show": false
                 },
@@ -1751,7 +1751,7 @@ For example you should create a group for the Introduction to Programming course
                     "generate_private_credential": false,
                     "auto_expiry": 1,
                     "signup_url_show": false,
-                    "signup_url": "https://example.com",
+                    "signup_url": "http://www.example.com",
                     "course_link_show": false,
                     "organization_link_show": false
                 }
@@ -1817,7 +1817,7 @@ For example you should create a group for the Introduction to Programming course
                     "generate_private_credential": false,
                     "auto_expiry": 1,
                     "signup_url_show": false,
-                    "signup_url": "https://example.com",
+                    "signup_url": "http://www.example.com",
                     "course_link_show": false,
                     "organization_link_show": false
                 },
@@ -1844,7 +1844,7 @@ For example you should create a group for the Introduction to Programming course
                     "generate_private_credential": false,
                     "auto_expiry": 1,
                     "signup_url_show": false,
-                    "signup_url": "https://example.com",
+                    "signup_url": "http://www.example.com",
                     "course_link_show": false,
                     "organization_link_show": false
                 }

--- a/apiary.apib
+++ b/apiary.apib
@@ -1456,7 +1456,7 @@ For example you should create a group for the Introduction to Programming course
         + meta_data (object, optional) - You can use this parameter to attach key-value strings to the object. Meta data is useful for storing additional, structured information on an object.
         + learning_outcomes(array, optional) - Searchable keywords identifying skills credential-holders need to demonstrate (or have learned) in the process of earning this credential.
         + generate_private_credential (boolean, optional) - The default value of `Credential.private` for the Group. The supported values are `true`, `false`, and `null`. When this is set to `true` or `false`, it will override `Department.generate_private_credential` and be used as the default of `Credential.private` when creating a new `Credential`. When this is set to `null`, it won't override `Department.generate_private_credential` which will be used for the default of `Credential.private` instead.
-        + auto_expiry (number, optional) - Set a date for when the credentials automatically expire after a certain amount of time has elapsed since the date of issue.
+        + auto_expiry (integer, optional) - Set a date for when the credentials automatically expire after a certain amount of time has elapsed since the date of issue.
         + signup_url (string, optional) - This provides a direct path for credential viewers to enroll in your course.
         + signup_url_show (boolean, optional) - Show or hide the sign up url. The supported values are `true`, `false` and `null`.
         + course_link_show (boolean, optional) - This links the credential data record to your information about the credential on your website. The supported values are `true`, `false` and `null`.
@@ -1593,7 +1593,7 @@ For example you should create a group for the Introduction to Programming course
         + meta_data (object, optional) - You can use this parameter to attach key-value strings to the object. Meta data is useful for storing additional, structured information on an object.
         + learning_outcomes(array, optional) - Searchable keywords identifying skills credential-holders need to demonstrate (or have learned) in the process of earning this credential.
         + generate_private_credential (boolean, optional) - The default value of `Credential.private` for the Group. The supported values are `true`, `false`, and `null`. When this is set to `true` or `false`, it will override `Department.generate_private_credential` and be used as the default of `Credential.private` when creating a new `Credential`. When this is set to `null`, it won't override `Department.generate_private_credential` which will be used for the default of `Credential.private` instead.
-        + auto_expiry (number, optional) - Set a date for when the credentials automatically expire after a certain amount of time has elapsed since the date of issue.
+        + auto_expiry (integer, optional) - Set a date for when the credentials automatically expire after a certain amount of time has elapsed since the date of issue.
         + signup_url (string, optional) - This provides a direct path for credential viewers to enroll in your course.
         + signup_url_show (boolean, optional) - Show or hide the sign up url. The supported values are `true`, `false` and `null`.
         + course_link_show (boolean, optional) - This links the credential data record to your information about the credential on your website. The supported values are `true`, `false` and `null`.

--- a/apiary.apib
+++ b/apiary.apib
@@ -1452,6 +1452,7 @@ For example you should create a group for the Introduction to Programming course
         + design_id (number, optional) - DEPRECATED. Certificate Design which the Group will use to display Credentials.
         + certificate_design_id (number, optional) - Certificate Design which the Group will use to display Credentials.
         + badge_design_id (number, optional) - Badge Design which the Group will use to display Credentials.
+        + primary_design_id (number, optional) - Primary Design which the Group will use to display Credentials.
         + department_id (number, optional) - Department that the group belongs to. If not defined the group will be assigned to the organizations default department.
         + meta_data (object, optional) - You can use this parameter to attach key-value strings to the object. Meta data is useful for storing additional, structured information on an object.
         + learning_outcomes(array, optional) - Searchable keywords identifying skills credential-holders need to demonstrate (or have learned) in the process of earning this credential.
@@ -1476,6 +1477,7 @@ For example you should create a group for the Introduction to Programming course
                     "blockchain": false,
                     "certificate_design_id": null,
                     "badge_design_id": null,
+                    "primary_design_id": null,
                     "department_id": 123,
                     "meta_data": {
                         "batch_id": "271"
@@ -1510,6 +1512,7 @@ For example you should create a group for the Introduction to Programming course
                 "blockchain": false,
                 "certificate_design_id": null,
                 "badge_design_id": null,
+                "primary_design_id": null,
                 "department_id": 123,
                 "meta_data": {
                     "foo": "bar"
@@ -1555,6 +1558,7 @@ For example you should create a group for the Introduction to Programming course
             "blockchain": false,
             "certificate_design_id": null,
             "badge_design_id": null,
+            "primary_design_id": null,
             "department_id": 123,
             "meta_data": null,
             "generate_private_credential": false,
@@ -1589,6 +1593,7 @@ For example you should create a group for the Introduction to Programming course
         + design_id (number,optional) - DEPRECATED. Certificate Design which the Group will use to display Credentials.
         + certificate_design_id (number,optional) - Certificate Design which the Group will use to display Credentials.
         + badge_design_id (number,optional) - Badge Design which the Group will use to display Credentials.
+        + primary_design_id (number, optional) - Primary Design which the Group will use to display Credentials.
         + department_id (number,optional) - Department that the group belongs to. If not defined the group will be assigned to the organizations default department.
         + meta_data (object, optional) - You can use this parameter to attach key-value strings to the object. Meta data is useful for storing additional, structured information on an object.
         + learning_outcomes(array, optional) - Searchable keywords identifying skills credential-holders need to demonstrate (or have learned) in the process of earning this credential.
@@ -1627,6 +1632,7 @@ For example you should create a group for the Introduction to Programming course
             "blockchain": false,
             "certificate_design_id": null,
             "badge_design_id": null,
+            "primary_design_id": null,
             "department_id": 123,
             "meta_data": {
                 "foo": "bar"
@@ -1670,6 +1676,7 @@ For example you should create a group for the Introduction to Programming course
             "blockchain": false,
             "certificate_design_id": null,
             "badge_design_id": null,
+            "primary_design_id": null,
             "department_id": 123,
             "meta_data": null,
             "generate_private_credential": false,
@@ -1717,6 +1724,7 @@ For example you should create a group for the Introduction to Programming course
                     "blockchain": false,
                     "certificate_design_id": 23,
                     "badge_design_id": null,
+                    "primary_design_id": 23,
                     "department_id": 123,
                     "meta_data": {
                         "course_id": "TK764"
@@ -1744,6 +1752,7 @@ For example you should create a group for the Introduction to Programming course
                     "design_id": null,
                     "certificate_design_id": null,
                     "badge_design_id": 345,
+                    "primary_design_id": null,
                     "department_id": 123,
                     "meta_data": {
                         "course_id": "TK765"
@@ -1810,6 +1819,7 @@ For example you should create a group for the Introduction to Programming course
                     "blockchain": false,
                     "certificate_design_id": 23,
                     "badge_design_id": null,
+                    "primary_design_id": 23,
                     "department_id": 123,
                     "meta_data": {
                         "course_id": "TK764"
@@ -1837,6 +1847,7 @@ For example you should create a group for the Introduction to Programming course
                     "design_id": null,
                     "certificate_design_id": null,
                     "badge_design_id": 345,
+                    "primary_design_id": null,
                     "department_id": 123,
                     "meta_data": {
                         "course_id": "TK765"

--- a/apiary.apib
+++ b/apiary.apib
@@ -1456,6 +1456,11 @@ For example you should create a group for the Introduction to Programming course
         + meta_data (object, optional) - You can use this parameter to attach key-value strings to the object. Meta data is useful for storing additional, structured information on an object.
         + learning_outcomes(array, optional) - Searchable keywords identifying skills credential-holders need to demonstrate (or have learned) in the process of earning this credential.
         + generate_private_credential (boolean, optional) - The default value of `Credential.private` for the Group. The supported values are `true`, `false`, and `null`. When this is set to `true` or `false`, it will override `Department.generate_private_credential` and be used as the default of `Credential.private` when creating a new `Credential`. When this is set to `null`, it won't override `Department.generate_private_credential` which will be used for the default of `Credential.private` instead.
+        + auto_expiry - (number, optional) - Expiration period for a Group credentials
+        + signup_url_show - (boolean, optional) - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        + signup_url - (string, optional) - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        + course_link_show - (boolean, optional) - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        + organization_link_show - (boolean, optional) - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 
     + Body
 
@@ -1476,7 +1481,12 @@ For example you should create a group for the Introduction to Programming course
                         "batch_id": "271"
                     },
                     "learning_outcomes": ["Reading Books", "Writing Essays"],
-                    "generate_private_credential": false
+                    "generate_private_credential": false,
+                    "auto_expiry": 2024,
+                    "signup_url_show": false,
+                    "signup_url": "https://example.com",
+                    "course_link_show": false,
+                    "organization_link_show": false
                 }
             }
 
@@ -1505,7 +1515,12 @@ For example you should create a group for the Introduction to Programming course
                     "foo": "bar"
                 },
                 "learning_outcomes": ["Skill One", "Skill Two"],
-                "generate_private_credential": false
+                "generate_private_credential": false,
+                "auto_expiry": 2024,
+                "signup_url_show": false,
+                "signup_url": "https://example.com",
+                "course_link_show": false,
+                "organization_link_show": false
             }
         }
 
@@ -1542,7 +1557,12 @@ For example you should create a group for the Introduction to Programming course
             "badge_design_id": null,
             "department_id": 123,
             "meta_data": null,
-            "generate_private_credential": false
+            "generate_private_credential": false,
+            "auto_expiry": 2024,
+            "signup_url_show": false,
+            "signup_url": "https://example.com",
+            "course_link_show": false,
+            "organization_link_show": false
           }
       }
 
@@ -1573,6 +1593,11 @@ For example you should create a group for the Introduction to Programming course
         + meta_data (object, optional) - You can use this parameter to attach key-value strings to the object. Meta data is useful for storing additional, structured information on an object.
         + learning_outcomes(array, optional) - Searchable keywords identifying skills credential-holders need to demonstrate (or have learned) in the process of earning this credential.
         + generate_private_credential (boolean, optional) - The default value of `Credential.private` for the Group. The supported values are `true`, `false`, and `null`. When this is set to `true` or `false`, it will override `Department.generate_private_credential` and be used as the default of `Credential.private` when creating a new `Credential`. When this is set to `null`, it won't override `Department.generate_private_credential` which will be used for the default of `Credential.private` instead.
+        + auto_expiry - (number, optional) - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        + signup_url_show - (boolean, optional) - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        + signup_url - (string, optional) - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        + course_link_show - (boolean, optional) - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        + organization_link_show - (boolean, optional) - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 
     + Body
 
@@ -1606,7 +1631,12 @@ For example you should create a group for the Introduction to Programming course
             "meta_data": {
                 "foo": "bar"
             },
-            "generate_private_credential": false
+            "generate_private_credential": false,
+            "auto_expiry": 2024,
+            "signup_url_show": false,
+            "signup_url": "https://example.com",
+            "course_link_show": false,
+            "organization_link_show": false
           }
         }
 
@@ -1642,7 +1672,12 @@ For example you should create a group for the Introduction to Programming course
             "badge_design_id": null,
             "department_id": 123,
             "meta_data": null,
-            "generate_private_credential": false
+            "generate_private_credential": false,
+            "auto_expiry": 2024,
+            "signup_url_show": false,
+            "signup_url": "https://example.com",
+            "course_link_show": false,
+            "organization_link_show": false
             }
         }
 
@@ -1686,7 +1721,12 @@ For example you should create a group for the Introduction to Programming course
                     "meta_data": {
                         "course_id": "TK764"
                     },
-                    "generate_private_credential": false
+                    "generate_private_credential": false,
+                    "auto_expiry": 2024,
+                    "signup_url_show": false,
+                    "signup_url": "https://example.com",
+                    "course_link_show": false,
+                    "organization_link_show": false
                 },
                 {
                     "id": 12473,
@@ -1708,7 +1748,12 @@ For example you should create a group for the Introduction to Programming course
                     "meta_data": {
                         "course_id": "TK765"
                     },
-                    "generate_private_credential": false
+                    "generate_private_credential": false,
+                    "auto_expiry": 2024,
+                    "signup_url_show": false,
+                    "signup_url": "https://example.com",
+                    "course_link_show": false,
+                    "organization_link_show": false
                 }
             ],
             "meta": {
@@ -1769,7 +1814,12 @@ For example you should create a group for the Introduction to Programming course
                     "meta_data": {
                         "course_id": "TK764"
                     },
-                    "generate_private_credential": false
+                    "generate_private_credential": false,
+                    "auto_expiry": 2024,
+                    "signup_url_show": false,
+                    "signup_url": "https://example.com",
+                    "course_link_show": false,
+                    "organization_link_show": false
                 },
                 {
                     "id": 12473,
@@ -1791,7 +1841,12 @@ For example you should create a group for the Introduction to Programming course
                     "meta_data": {
                         "course_id": "TK765"
                     },
-                    "generate_private_credential": false
+                    "generate_private_credential": false,
+                    "auto_expiry": 2024,
+                    "signup_url_show": false,
+                    "signup_url": "https://example.com",
+                    "course_link_show": false,
+                    "organization_link_show": false
                 }
             ],
             "meta": {

--- a/apiary.apib
+++ b/apiary.apib
@@ -1456,11 +1456,11 @@ For example you should create a group for the Introduction to Programming course
         + meta_data (object, optional) - You can use this parameter to attach key-value strings to the object. Meta data is useful for storing additional, structured information on an object.
         + learning_outcomes(array, optional) - Searchable keywords identifying skills credential-holders need to demonstrate (or have learned) in the process of earning this credential.
         + generate_private_credential (boolean, optional) - The default value of `Credential.private` for the Group. The supported values are `true`, `false`, and `null`. When this is set to `true` or `false`, it will override `Department.generate_private_credential` and be used as the default of `Credential.private` when creating a new `Credential`. When this is set to `null`, it won't override `Department.generate_private_credential` which will be used for the default of `Credential.private` instead.
-        + auto_expiry - (number, optional) - If the Group's credentials expire, it's important to set an expiration period. Add a year to say how long the credentials for this group should be valid.
-        + signup_url_show - (boolean, optional) - Show or hide the sign up url. The supported values are `true`, `false` and `null`.
-        + signup_url - (string, optional) - This provides a direct path for credential viewers in the Group to enrol on your course.
-        + course_link_show - (boolean, optional) - You can use this parameter to show or hide the page on your website specifically regarding the course the credential was issued for. The supported values are `true`, `false` and `null`
-        + organization_link_show - (boolean, optional) - You can use this parameter to show or hide the link to your website homepage. The supported values are `true`, `false` and `null`
+        + auto_expiry (number, optional) - If the Group's credentials expire, it's important to set an expiration period. Add a number to say how long the credentials for this group should be valid. e.g. 1 means expires in 1 year.
+        + signup_url_show (boolean, optional) - Show or hide the sign up url. The supported values are `true`, `false` and `null`.
+        + signup_url (string, optional) - This provides a direct path for credential viewers in the Group to enrol on your course.
+        + course_link_show (boolean, optional) - You can use this parameter to show or hide the page on your website specifically regarding the course the credential was issued for. The supported values are `true`, `false` and `null`
+        + organization_link_show (boolean, optional) - You can use this parameter to show or hide the link to your website homepage. The supported values are `true`, `false` and `null`
 
     + Body
 
@@ -1482,7 +1482,7 @@ For example you should create a group for the Introduction to Programming course
                     },
                     "learning_outcomes": ["Reading Books", "Writing Essays"],
                     "generate_private_credential": false,
-                    "auto_expiry": 2024,
+                    "auto_expiry": 1,
                     "signup_url_show": false,
                     "signup_url": "https://example.com",
                     "course_link_show": false,
@@ -1516,7 +1516,7 @@ For example you should create a group for the Introduction to Programming course
                 },
                 "learning_outcomes": ["Skill One", "Skill Two"],
                 "generate_private_credential": false,
-                "auto_expiry": 2024,
+                "auto_expiry": 1,
                 "signup_url_show": false,
                 "signup_url": "https://example.com",
                 "course_link_show": false,
@@ -1558,7 +1558,7 @@ For example you should create a group for the Introduction to Programming course
             "department_id": 123,
             "meta_data": null,
             "generate_private_credential": false,
-            "auto_expiry": 2024,
+            "auto_expiry": 1,
             "signup_url_show": false,
             "signup_url": "https://example.com",
             "course_link_show": false,
@@ -1593,11 +1593,11 @@ For example you should create a group for the Introduction to Programming course
         + meta_data (object, optional) - You can use this parameter to attach key-value strings to the object. Meta data is useful for storing additional, structured information on an object.
         + learning_outcomes(array, optional) - Searchable keywords identifying skills credential-holders need to demonstrate (or have learned) in the process of earning this credential.
         + generate_private_credential (boolean, optional) - The default value of `Credential.private` for the Group. The supported values are `true`, `false`, and `null`. When this is set to `true` or `false`, it will override `Department.generate_private_credential` and be used as the default of `Credential.private` when creating a new `Credential`. When this is set to `null`, it won't override `Department.generate_private_credential` which will be used for the default of `Credential.private` instead.
-        + auto_expiry - (number, optional) - If the Group's credentials expire, it's important to set an expiration period. Add a year to say how long the credentials for this group should be valid.
-        + signup_url_show - (boolean, optional) - Show or hide the sign up url. The supported values are `true`, `false` and `null`.
-        + signup_url - (string, optional) - This provides a direct path for credential viewers in the Group to enrol on your course.
-        + course_link_show - (boolean, optional) - You can use this parameter to show or hide the page on your website specifically regarding the course the credential was issued for. The supported values are `true`, `false` and `null`
-        + organization_link_show - (boolean, optional) - You can use this parameter to show or hide the link to your website homepage. The supported values are `true`, `false` and `null`
+        + auto_expiry (number, optional) - If the Group's credentials expire, it's important to set an expiration period. Add a number to say how long the credentials for this group should be valid. e.g. 1 means expires in 1 year.
+        + signup_url_show (boolean, optional) - Show or hide the sign up url. The supported values are `true`, `false` and `null`.
+        + signup_url (string, optional) - This provides a direct path for credential viewers in the Group to enrol on your course.
+        + course_link_show (boolean, optional) - You can use this parameter to show or hide the page on your website specifically regarding the course the credential was issued for. The supported values are `true`, `false` and `null`
+        + organization_link_show (boolean, optional) - You can use this parameter to show or hide the link to your website homepage. The supported values are `true`, `false` and `null`
 
     + Body
 
@@ -1632,7 +1632,7 @@ For example you should create a group for the Introduction to Programming course
                 "foo": "bar"
             },
             "generate_private_credential": false,
-            "auto_expiry": 2024,
+            "auto_expiry": 1,
             "signup_url_show": false,
             "signup_url": "https://example.com",
             "course_link_show": false,
@@ -1673,7 +1673,7 @@ For example you should create a group for the Introduction to Programming course
             "department_id": 123,
             "meta_data": null,
             "generate_private_credential": false,
-            "auto_expiry": 2024,
+            "auto_expiry": 1,
             "signup_url_show": false,
             "signup_url": "https://example.com",
             "course_link_show": false,
@@ -1722,7 +1722,7 @@ For example you should create a group for the Introduction to Programming course
                         "course_id": "TK764"
                     },
                     "generate_private_credential": false,
-                    "auto_expiry": 2024,
+                    "auto_expiry": 1,
                     "signup_url_show": false,
                     "signup_url": "https://example.com",
                     "course_link_show": false,
@@ -1749,7 +1749,7 @@ For example you should create a group for the Introduction to Programming course
                         "course_id": "TK765"
                     },
                     "generate_private_credential": false,
-                    "auto_expiry": 2024,
+                    "auto_expiry": 1,
                     "signup_url_show": false,
                     "signup_url": "https://example.com",
                     "course_link_show": false,
@@ -1815,7 +1815,7 @@ For example you should create a group for the Introduction to Programming course
                         "course_id": "TK764"
                     },
                     "generate_private_credential": false,
-                    "auto_expiry": 2024,
+                    "auto_expiry": 1,
                     "signup_url_show": false,
                     "signup_url": "https://example.com",
                     "course_link_show": false,
@@ -1842,7 +1842,7 @@ For example you should create a group for the Introduction to Programming course
                         "course_id": "TK765"
                     },
                     "generate_private_credential": false,
-                    "auto_expiry": 2024,
+                    "auto_expiry": 1,
                     "signup_url_show": false,
                     "signup_url": "https://example.com",
                     "course_link_show": false,

--- a/apiary.apib
+++ b/apiary.apib
@@ -1456,11 +1456,11 @@ For example you should create a group for the Introduction to Programming course
         + meta_data (object, optional) - You can use this parameter to attach key-value strings to the object. Meta data is useful for storing additional, structured information on an object.
         + learning_outcomes(array, optional) - Searchable keywords identifying skills credential-holders need to demonstrate (or have learned) in the process of earning this credential.
         + generate_private_credential (boolean, optional) - The default value of `Credential.private` for the Group. The supported values are `true`, `false`, and `null`. When this is set to `true` or `false`, it will override `Department.generate_private_credential` and be used as the default of `Credential.private` when creating a new `Credential`. When this is set to `null`, it won't override `Department.generate_private_credential` which will be used for the default of `Credential.private` instead.
-        + auto_expiry - (number, optional) - Expiration period for a Group credentials
-        + signup_url_show - (boolean, optional) - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-        + signup_url - (string, optional) - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-        + course_link_show - (boolean, optional) - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-        + organization_link_show - (boolean, optional) - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        + auto_expiry - (number, optional) - If the Group's credentials expire, it's important to set an expiration period. Add a year to say how long the credentials for this group should be valid.
+        + signup_url_show - (boolean, optional) - Show or hide the sign up url. The supported values are `true`, `false` and `null`.
+        + signup_url - (string, optional) - This provides a direct path for credential viewers in the Group to enrol on your course.
+        + course_link_show - (boolean, optional) - You can use this parameter to show or hide the page on your website specifically regarding the course the credential was issued for. The supported values are `true`, `false` and `null`
+        + organization_link_show - (boolean, optional) - You can use this parameter to show or hide the link to your website homepage. The supported values are `true`, `false` and `null`
 
     + Body
 
@@ -1593,11 +1593,11 @@ For example you should create a group for the Introduction to Programming course
         + meta_data (object, optional) - You can use this parameter to attach key-value strings to the object. Meta data is useful for storing additional, structured information on an object.
         + learning_outcomes(array, optional) - Searchable keywords identifying skills credential-holders need to demonstrate (or have learned) in the process of earning this credential.
         + generate_private_credential (boolean, optional) - The default value of `Credential.private` for the Group. The supported values are `true`, `false`, and `null`. When this is set to `true` or `false`, it will override `Department.generate_private_credential` and be used as the default of `Credential.private` when creating a new `Credential`. When this is set to `null`, it won't override `Department.generate_private_credential` which will be used for the default of `Credential.private` instead.
-        + auto_expiry - (number, optional) - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-        + signup_url_show - (boolean, optional) - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-        + signup_url - (string, optional) - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-        + course_link_show - (boolean, optional) - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-        + organization_link_show - (boolean, optional) - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        + auto_expiry - (number, optional) - If the Group's credentials expire, it's important to set an expiration period. Add a year to say how long the credentials for this group should be valid.
+        + signup_url_show - (boolean, optional) - Show or hide the sign up url. The supported values are `true`, `false` and `null`.
+        + signup_url - (string, optional) - This provides a direct path for credential viewers in the Group to enrol on your course.
+        + course_link_show - (boolean, optional) - You can use this parameter to show or hide the page on your website specifically regarding the course the credential was issued for. The supported values are `true`, `false` and `null`
+        + organization_link_show - (boolean, optional) - You can use this parameter to show or hide the link to your website homepage. The supported values are `true`, `false` and `null`
 
     + Body
 


### PR DESCRIPTION
Updates all Group Public API endpoints to have the additional attributes documented:

Attribute | Date type 
-- | --
auto_expiry | integer (year) 
signup_url_show | boolean
signup_url | text
course_link_show | boolean 
organization_link_show | boolean


Wording for attributes description to be confirmed by Kelly 

`primary_design_id` added as was in the response of the API but not documented
