### PR TITLE
DGR-88: Fix date format discrepancies

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -176,8 +176,8 @@ This endpoint requires a JSON object containing a Credential.
         + name (string, optional) - The Credential/course name displayed to recipients. This is required if the Group the Credential belongs to doesn't have a Course Name set.
         + description (string, optional) - The credential/course description displayed to recipients. This is required if the Group the Credential belongs to doesn't have a Course Description set.
         + custom_attributes (object, optional) - Custom variables to display on the Credential. These should be added to the design using the visual editor. Data should be formatted as a JSON hash where keys are the custom attribute names and the values are the values to be displayed on the Credential.
-        + issued_on (string, optional) - Date of issue, the default is when the credential is created. Format: DD/MM/YYYY
-        + expired_on (string, optional) - Date you would like the credential to expire on, null by default. Format: DD/MM/YYYY
+        + issued_on (string, optional) - Date of issue, the default is when the credential is created. Format: YYYY-MM-DD (DD/MM/YYYY also works but is deprecated)
+        + expired_on (string, optional) - Date you would like the credential to expire on, null by default. Format: YYYY-MM-DD (DD/MM/YYYY also works but is deprecated)
         + complete (boolean, optional) - Whether the achievement is complete or still in progress, true by default.
         + private (boolean, optional) - Whether to make credential private. When it is set to `true`, the Credential will be private and visible only to its recipient who has signed into credential.net. If no value is set, the default value will be automatically assigned based on `Group.generate_private_credential` and `Department.generate_private_credential`. `Department.generate_private_credential` will be used as the default when `Group.generate_private_credential` is set to `null`. `Group.generate_private_credential` will override `Department.generate_private_credential` and be used as the default when it is set to `true` or `false`.
         + approve (boolean, optional) - Whether to publish credential at the time of creation. By default this is true but settings at dashboard for sandbox_mode take precendence.
@@ -554,8 +554,8 @@ Create multiple Credentials using this action. It requires a JSON object contain
         + name (string, optional) - The Credential/course name displayed to recipients. This is required if the Group the Credential belongs to doesn't have a Course Name set.
         + description (string, optional) - The credential/course description displayed to recipients. This is required if the Group the Credential belongs to doesn't have a Course Description set.
         + custom_attributes (object, optional) - Custom variables to display on the Credential. These should be added to the design using the visual editor. Data should be formatted as a JSON hash where keys are the custom attribute names and the values are the values to be displayed on the Credential.
-        + issued_on (string, optional) - Date of issue, the default is when the credential is created. Format: DD/MM/YYYY
-        + expired_on (string, optional) - Date you would like the credential to expire on, null by default. Format: DD/MM/YYYY
+        + issued_on (string, optional) - Date of issue, the default is when the credential is created. Format: YYYY-MM-DD (DD/MM/YYYY also works but is deprecated)
+        + expired_on (string, optional) - Date you would like the credential to expire on, null by default. Format: YYYY-MM-DD (DD/MM/YYYY also works but is deprecated)
         + complete (boolean, optional) - Whether the achievement is complete or still in progress, true by default.
         + allow_supplemental_evidence (boolean, optional) - Whether to allow recipients to add their own supplemental evidence to the Credential, true by default.
         + allow_supplemental_references (boolean, optional) - Whether to allow recipients to add their own supplemental references to the credential, true by default.
@@ -771,10 +771,10 @@ Create multiple Credentials using this action. It requires a JSON object contain
     + email (string, optional) - Limit the returned Credentials to a specific recipient's email address.
     + recipient_id (string, optional) - Limit the returned Credentials to a specific recipient user identifier (ID) you set whilst creating Credentials.
     + license_id (string, optional) - Limit the returned Credential to a specific credential id you set whilst creating credential.
-    + start_date (string, optional) - Date after which credentials issued should be return. Format: DD/MM/YYYY
-    + end_date (string, optional) - Date before which credetials issued should be return. Format: DD/MM/YYYY
-    + start_updated_date (string, optional) - Date after which Credentials updated should be returned. Format: DD/MM/YYYY
-    + end_updated_date (string, optional) - Date before which Credentials updated should be returned. Format: DD/MM/YYYY
+    + start_date (string, optional) - Date after which credentials issued should be return. Format: YYYY-MM-DD (DD/MM/YYYY also works but is deprecated)
+    + end_date (string, optional) - Date before which credetials issued should be return. Format: YYYY-MM-DD (DD/MM/YYYY also works but is deprecated)
+    + start_updated_date (string, optional) - Date after which Credentials updated should be returned. Format: YYYY-MM-DD (DD/MM/YYYY also works but is deprecated)
+    + end_updated_date (string, optional) - Date before which Credentials updated should be returned. Format: YYYY-MM-DD (DD/MM/YYYY also works but is deprecated)
     + page_size(number, optional) - The pagination response size, default of 50.
     + page(number,optional) - The pagination page.
 
@@ -794,7 +794,7 @@ Create multiple Credentials using this action. It requires a JSON object contain
                 "description": "Test Description",
                 "grade": null,
                 "complete": true,
-                "issued_on": "2015-07-03T07:10:04.000Z",
+                "issued_on": "2015-07-03",
                 "allow_supplemental_references": null,
                 "allow_supplemental_evidence": null,
                 "course_link": "http://example.com",
@@ -825,7 +825,7 @@ Create multiple Credentials using this action. It requires a JSON object contain
                 "description": "Test Description",
                 "grade": null,
                 "complete": true,
-                "issued_on": "2015-07-03T07:10:04.000Z",
+                "issued_on": "2015-07-03",
                 "allow_supplemental_references": null,
                 "allow_supplemental_evidence": null,
                 "course_link": "http://example.com",
@@ -868,10 +868,10 @@ Create multiple Credentials using this action. It requires a JSON object contain
     + recipient.meta_data (object, optional) - String key/values for client's own data on recipient
     + license_id (string, optional) - Limit the returned Credential to a specific credential id you set whilst creating credential.
     + meta_data (object, optional) - String key/values for client's own data on credential
-    + start_date (string, optional) - Date after which credentials issued should be return. Format: DD/MM/YYYY
-    + end_date (string, optional) - Date before which credetials issued should be return. Format: DD/MM/YYYY
-    + start_updated_date (string, optional) - Date after which Credentials updated should be returned. Format: DD/MM/YYYY
-    + end_updated_date (string, optional) - Date before which Credetials updated should be returned. Format: DD/MM/YYYY
+    + start_date (string, optional) - Date after which credentials issued should be return. Format: YYYY-MM-DD (DD/MM/YYYY also works but is deprecated)
+    + end_date (string, optional) - Date before which credetials issued should be return. Format: YYYY-MM-DD (DD/MM/YYYY also works but is deprecated)
+    + start_updated_date (string, optional) - Date after which Credentials updated should be returned. Format: YYYY-MM-DD (DD/MM/YYYY also works but is deprecated)
+    + end_updated_date (string, optional) - Date before which Credetials updated should be returned. Format: YYYY-MM-DD (DD/MM/YYYY also works but is deprecated)
     + page_size(number, optional) - The pagination response size, default of 50.
     + page(number,optional) - The pagination page.
 
@@ -898,7 +898,7 @@ Create multiple Credentials using this action. It requires a JSON object contain
                 "description": "Test Description",
                 "grade": null,
                 "complete": true,
-                "issued_on": "2015-07-03T07:10:04.000Z",
+                "issued_on": "2015-07-03",
                 "allow_supplemental_references": null,
                 "allow_supplemental_evidence": null,
                 "course_link": "http://example.com",
@@ -929,7 +929,7 @@ Create multiple Credentials using this action. It requires a JSON object contain
                 "description": "Test Description",
                 "grade": null,
                 "complete": true,
-                "issued_on": "2015-07-03T07:10:04.000Z",
+                "issued_on": "2015-07-03",
                 "allow_supplemental_references": null,
                 "allow_supplemental_evidence": null,
                 "course_link": "http://example.com",
@@ -1049,7 +1049,7 @@ Following operations will be **supported based on the field**. You can also comb
                         "name": "Analytics",
                     },
                     "approve": true,
-                    "issued_on": "Tue, 13 Aug 2022 12:11:05 UTC +00:00",
+                    "issued_on": "2022-08-13",
                     "custom_attributes": {
                         "zen_value": "medium"
                     },
@@ -1059,18 +1059,18 @@ Following operations will be **supported based on the field**. You can also comb
                     "recipient_meta_data": {
                         "foo": "bar"
                     },
-                    "expired_on": "Sat, 23 Aug 2025",
+                    "expired_on": "2025-08-23",
                     "private": false,
                     "recipient_email": "test@accredible.com",
                     "recipient_name": "Test Recipient",
                     "recipient_engaged": false,
                     "recipient_opened": true,
                     "recipient_id": 50,
-                    "created_at": "Tue, 13 Aug 2022 12:11:05 UTC +00:00",
-                    "updated_at": "Tue, 13 Aug 2022 12:11:05 UTC +00:00",
+                    "created_at": "2022-08-13T12:11:05.001Z",
+                    "updated_at": "2022-08-13T12:11:05.001Z",
                     "issuer_id": 60,
                     "license_id": "l001",
-                    "published_on": "Tue, 13 Aug 2022 12:11:05 UTC +00:00",
+                    "published_on": "2022-08-13",
                     "uuid": "60438da7-8c09-4a69-b2a7-ab4b3cf4f569"
                 }
             ],
@@ -1782,8 +1782,8 @@ For example you should create a group for the Introduction to Programming course
 + Parameters
     + name(string, optional) - Limit the list of Groups to those named with the given string.
     + meta_data (object, optional) - String key/values for client's own data on group
-    + start_updated_date (string, optional) - Date after which Groups which have been updated should be returned. Format: DD/MM/YYYY
-    + end_updated_date (string, optional) - Date before which Groups which have been updated should be returned. Format: DD/MM/YYYY
+    + start_updated_date (string, optional) - Date after which Groups which have been updated should be returned. Format: YYYY-MM-DD (DD/MM/YYYY also works but is deprecated)
+    + end_updated_date (string, optional) - Date before which Groups which have been updated should be returned. Format: YYYY-MM-DD (DD/MM/YYYY also works but is deprecated)
     + page_size(number, optional) - The pagination response size, default of 50.
     + page(number,optional) - The pagination page.
 
@@ -2955,8 +2955,8 @@ Your Accredible account is represented as an Issuer within the API.
 ### Index Analytics [GET]
 
 + Parameters
-    + start_date (date, optional) - Only return Credential analytic events recoreded after the given start date. Format: YYYY/MM/DD.
-    + end_date (date, optional) - Only return Credential analytic events recoreded before the given end date. Format: YYYY/MM/DD.
+    + start_date (date, optional) - Only return Credential analytic events recoreded after the given start date. Format: YYYY-MM-DD (YYYY/MM/DD also works but is deprecated)
+    + end_date (date, optional) - Only return Credential analytic events recoreded before the given end date. Format: YYYY-MM-DD (YYYY/MM/DD also works but is deprecated)
     + group_id (integer, optional) - Only return Credential analytic events relating to Credentials within the given Group.
     + department_id (integer, optional) - Only return Credential analytic events relating to Credentials within the given Department.
     + page_size(number, optional) - The pagination response size, default of 100.


### PR DESCRIPTION
Source: https://accredible.atlassian.net/browse/DGR-88

This PR fixes date format discrepancies in the API document and makes it consistent as `YYYY-MM-DD`. I've made sure those endpoints can also support the format YYYY-MM-DD in the request as they're using `Date.parse`.

I also fixed incorrect response examples in the date/datetime fields.