### PR TITLE
[DGR-2123] Remove incorrect payload attributes from collections PUT request

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2296,6 +2296,22 @@ To create one, you'll need to provide a collection name, a description, and indi
 
 + Response 200 (application/json)
 
+        {
+            "collection": {
+                "id": "809fxsq0-fx89-11ef-8c4a-b7d12b7poib3",
+                "name": "Collection name",
+                "description": "DESCRIPTION",
+                "organization_id": 231,
+                "public": true,
+                "groups_count": 3,
+                "groups": [
+                    {"id": 1},
+                    {"id": 2},
+                    {"id": 3}
+                ]
+            }
+        }
+
 ### Delete a Collection [DELETE]
 
 + Parameters

--- a/apiary.apib
+++ b/apiary.apib
@@ -2290,8 +2290,6 @@ To create one, you'll need to provide a collection name, a description, and indi
                     "name": "Collection name",
                     "description": "DESCRIPTION",
                     "public": true,
-                    "organization_id": 1,
-                    "groups_count": 22,
                     "groups": [{"id": 1}, {"id": 2}, {"id": 3}]
                 }
             }

--- a/apiary.apib
+++ b/apiary.apib
@@ -2256,14 +2256,23 @@ To create one, you'll need to provide a collection name, a description, and indi
                 "collection": {
                     "name": "Collection name",
                     "description": "DESCRIPTION",
-                    "public": true,
-                    "organization_id": 1,
-                    "groups_count": 0,
-                    "groups": []
+                    "public": true
                 }
             }
 
 + Response 200 (application/json)
+
+        {
+            "collection": {
+                "id": "809fxsq0-fx89-11ef-8c4a-b7d12b7poib3",
+                "name": "Collection name",
+                "description": "DESCRIPTION",
+                "organization_id": 231,
+                "public": true,
+                "groups_count": 0,
+                "groups": []
+            }
+        }
 
 ## Collection [/v1/collections/{collection_id}]
 ### Update a Collection [PUT]


### PR DESCRIPTION
Fix Collections API documentation by removing incorrect payload attributes from request examples that should only appear in responses.

## Changes Made
- **POST Create Collection**: Removed `organization_id`, `groups_count`, and `groups` from request payload example
- **PUT Update Collection**: Removed `organization_id` and `groups_count` from request payload example  
- **Both endpoints**: Added proper 200 response examples showing complete collection data
- **Request examples**: Now only show fields that are actually accepted as input parameters


**Collections POST create**

![Screenshot 2025-07-07 at 11 12 06](https://github.com/user-attachments/assets/2be6e621-9720-4f65-9e70-4f774b8bc91d)

**Collections PUT update**

![Screenshot 2025-07-07 at 11 13 08](https://github.com/user-attachments/assets/faba269a-32bb-4112-8419-924b14312e52)


