### PR TITLE
Use meta for pagination in /v1/collections/search endpoint documentation

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2350,7 +2350,7 @@ To create one, you'll need to provide a collection name, a description, and indi
         + String key/value pair for sorting based on a field and order.
         Supported keys - `name`, `groups_count` and `public`
         Supported values - `asc`, `desc`
-    + page (object, optional)
+    + meta (object, optional)
         + page_number - Defines the number of page wanted
         + per_page - The number of records to be returned
 
@@ -2364,7 +2364,7 @@ To create one, you'll need to provide a collection name, a description, and indi
 
         {
             "query": {
-                "ids": ["809fxsq0-fx89-11ef-8c4a-b7d12b7poib3"]
+                "ids": ["809fxsq0-fx89-11ef-8c4a-b7d12b7poib3"],
                 "name": "abc",
                 "public": true,
                 "exclusion_list": [
@@ -2373,7 +2373,7 @@ To create one, you'll need to provide a collection name, a description, and indi
                 ]
             },
             "sort": {
-                "field": asc"
+                "field": "asc"
             },
             "meta": {
                 "page_number": 1,


### PR DESCRIPTION
This PR updates the API documentation for the `/v1/collections/search` endpoint to use the correct `meta` object for pagination parameters in the request body, instead of the incorrect `page` object. The example request and response have been updated to reflect this change, ensuring consistency with the actual API behavior and improving developer experience.

**Current:**
<img width="693" height="448" alt="Screenshot 2025-07-11 at 15 18 08" src="https://github.com/user-attachments/assets/653cf01a-902a-4c42-9c9d-d13b3e76e56a" />

**Fix:**
<img width="668" height="674" alt="Screenshot 2025-07-11 at 15 20 10" src="https://github.com/user-attachments/assets/3ade05bb-29fc-4d72-aa25-0a9e30029c72" />

