### PR TITLE
[HDR-5672] Document pathways permission for Team Members endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -9091,6 +9091,9 @@
                                   "role": {
                                     "type": "string"
                                   },
+                                  "pathways": {
+                                    "type": "boolean"
+                                  },
                                   "groups": {
                                     "type": "array",
                                     "items": {
@@ -9133,6 +9136,7 @@
                           "analytics": true,
                           "settings": true,
                           "role": "editor",
+                          "pathways": true,
                           "groups": [1, 2, 3]
                         }
                       },
@@ -9145,6 +9149,7 @@
                           "analytics": false,
                           "settings": false,
                           "role": "viewer",
+                          "pathways": false,
                           "groups": null
                         }
                       }
@@ -9178,6 +9183,7 @@
                         "analytics": true,
                         "settings": true,
                         "role": "editor",
+                        "pathways": true,
                         "groups": [1, 2, 3]
                       }
                     },
@@ -9190,6 +9196,7 @@
                         "analytics": false,
                         "settings": false,
                         "role": "viewer",
+                        "pathways": false,
                         "groups": null
                       }
                     }
@@ -9244,6 +9251,11 @@
                               "type": "string",
                               "description": "\"editor\" or \"viewer\" access to Credential data in the Department."
                             },
+                            "pathways": {
+                              "type": "boolean",
+                              "default": false,
+                              "description": "Should the TeamMember have access to Pathways for the given Department?"
+                            },
                             "groups": {
                               "type": "array",
                               "description": "Limit the TeamMember access to specific Groups in the Department.",
@@ -9287,7 +9299,7 @@
           {
             "lang": "cURL",
             "label": "cURL",
-            "source": "curl -X POST \\\n  \"https://api.accredible.com/v1/team_members\" \\\n  -H \"Authorization: Token token=YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"team_member\": {\n    \"name\": \"John Doe\",\n    \"email\": \"person@example.com\",\n    \"department_permissions\": [\n      {\n        \"department_id\": 34,\n        \"permissions\": {\n          \"designs\": true,\n          \"emails\": true,\n          \"credential_attributes\": true,\n          \"analytics\": true,\n          \"settings\": true,\n          \"role\": \"editor\",\n          \"groups\": [1, 2, 3]\n        }\n      },\n      {\n        \"department_id\": 35,\n        \"permissions\": {\n          \"designs\": false,\n          \"emails\": false,\n          \"credential_attributes\": false,\n          \"analytics\": false,\n          \"settings\": false,\n          \"role\": \"viewer\",\n          \"groups\": null\n        }\n      }\n    ]\n  }\n}'"
+            "source": "curl -X POST \\\n  \"https://api.accredible.com/v1/team_members\" \\\n  -H \"Authorization: Token token=YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"team_member\": {\n    \"name\": \"John Doe\",\n    \"email\": \"person@example.com\",\n    \"department_permissions\": [\n      {\n        \"department_id\": 34,\n        \"permissions\": {\n          \"designs\": true,\n          \"emails\": true,\n          \"credential_attributes\": true,\n          \"analytics\": true,\n          \"settings\": true,\n          \"role\": \"editor\",\n          \"pathways\": true,\n          \"groups\": [1, 2, 3]\n        }\n      },\n      {\n        \"department_id\": 35,\n        \"permissions\": {\n          \"designs\": false,\n          \"emails\": false,\n          \"credential_attributes\": false,\n          \"analytics\": false,\n          \"settings\": false,\n          \"role\": \"viewer\",\n          \"pathways\": false,\n          \"groups\": null\n        }\n      }\n    ]\n  }\n}'"
           }
         ]
       }
@@ -9344,6 +9356,9 @@
                                   "role": {
                                     "type": "string"
                                   },
+                                  "pathways": {
+                                    "type": "boolean"
+                                  },
                                   "groups": {
                                     "type": "array",
                                     "items": {
@@ -9379,6 +9394,7 @@
                           "analytics": true,
                           "settings": true,
                           "role": "editor",
+                          "pathways": true,
                           "groups": [
                             1,
                             2,
@@ -9395,6 +9411,7 @@
                           "analytics": false,
                           "settings": false,
                           "role": "viewer",
+                          "pathways": false,
                           "groups": null
                         }
                       }
@@ -9429,7 +9446,116 @@
           "200": {
             "description": "OK",
             "headers": {},
-            "content": {}
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "team_member": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "number"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "email": {
+                          "type": "string"
+                        },
+                        "department_permissions": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "department_id": {
+                                "type": "number"
+                              },
+                              "permissions": {
+                                "type": "object",
+                                "properties": {
+                                  "designs": {
+                                    "type": "boolean"
+                                  },
+                                  "emails": {
+                                    "type": "boolean"
+                                  },
+                                  "credential_attributes": {
+                                    "type": "boolean"
+                                  },
+                                  "analytics": {
+                                    "type": "boolean"
+                                  },
+                                  "settings": {
+                                    "type": "boolean"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "pathways": {
+                                    "type": "boolean"
+                                  },
+                                  "groups": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "number"
+                                    },
+                                    "nullable": true
+                                  }
+                                }
+                              }
+                            },
+                            "required": [
+                              "department_id",
+                              "permissions"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "team_member": {
+                    "id": 12345,
+                    "name": "John Doe",
+                    "email": "person@example.com",
+                    "department_permissions": [
+                      {
+                        "department_id": 34,
+                        "permissions": {
+                          "designs": false,
+                          "emails": false,
+                          "credential_attributes": true,
+                          "analytics": true,
+                          "settings": true,
+                          "role": "editor",
+                          "pathways": true,
+                          "groups": [
+                            1,
+                            2,
+                            3
+                          ]
+                        }
+                      },
+                      {
+                        "department_id": 35,
+                        "permissions": {
+                          "designs": false,
+                          "emails": false,
+                          "credential_attributes": false,
+                          "analytics": false,
+                          "settings": false,
+                          "role": "viewer",
+                          "pathways": false,
+                          "groups": null
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
           }
         },
         "summary": "Update a Team Member",
@@ -9453,6 +9579,7 @@
                         "analytics": true,
                         "settings": true,
                         "role": "editor",
+                        "pathways": true,
                         "groups": [
                           1,
                           2,
@@ -9469,6 +9596,7 @@
                         "analytics": false,
                         "settings": false,
                         "role": "viewer",
+                        "pathways": false,
                         "groups": null
                       }
                     }
@@ -9526,6 +9654,11 @@
                               "type": "string",
                               "description": "\"editor\" or \"viewer\" access to Credential data in the Department."
                             },
+                            "pathways": {
+                              "type": "boolean",
+                              "default": false,
+                              "description": "Should the TeamMember have access to Pathways for the given Department?"
+                            },
                             "groups": {
                               "description": "Limit the TeamMember access to specific Groups in the Department."
                             }
@@ -9564,7 +9697,7 @@
           {
             "lang": "cURL",
             "label": "cURL",
-            "source": "curl -X PUT \\\n  \"https://api.accredible.com/v1/team_members/12345\" \\\n  -H \"Authorization: Token token=YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"team_member\": {\n    \"department_permissions\": [\n      {\n        \"department_id\": 34,\n        \"permissions\": {\n          \"designs\": false,\n          \"emails\": false,\n          \"credential_attributes\": true,\n          \"analytics\": true,\n          \"settings\": true,\n          \"role\": \"editor\",\n          \"groups\": [\n            1,\n            2,\n            3\n          ]\n        }\n      },\n      {\n        \"department_id\": 35,\n        \"permissions\": {\n          \"designs\": false,\n          \"emails\": false,\n          \"credential_attributes\": false,\n          \"analytics\": false,\n          \"settings\": false,\n          \"role\": \"viewer\",\n          \"groups\": null\n        }\n      }\n    ]\n  }\n}'"
+            "source": "curl -X PUT \\\n  \"https://api.accredible.com/v1/team_members/12345\" \\\n  -H \"Authorization: Token token=YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n  \"team_member\": {\n    \"department_permissions\": [\n      {\n        \"department_id\": 34,\n        \"permissions\": {\n          \"designs\": false,\n          \"emails\": false,\n          \"credential_attributes\": true,\n          \"analytics\": true,\n          \"settings\": true,\n          \"role\": \"editor\",\n          \"pathways\": true,\n          \"groups\": [\n            1,\n            2,\n            3\n          ]\n        }\n      },\n      {\n        \"department_id\": 35,\n        \"permissions\": {\n          \"designs\": false,\n          \"emails\": false,\n          \"credential_attributes\": false,\n          \"analytics\": false,\n          \"settings\": false,\n          \"role\": \"viewer\",\n          \"pathways\": false,\n          \"groups\": null\n        }\n      }\n    ]\n  }\n}'"
           }
         ]
       },
@@ -9573,7 +9706,116 @@
           "200": {
             "description": "OK",
             "headers": {},
-            "content": {}
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "team_member": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "number"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "email": {
+                          "type": "string"
+                        },
+                        "department_permissions": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "department_id": {
+                                "type": "number"
+                              },
+                              "permissions": {
+                                "type": "object",
+                                "properties": {
+                                  "designs": {
+                                    "type": "boolean"
+                                  },
+                                  "emails": {
+                                    "type": "boolean"
+                                  },
+                                  "credential_attributes": {
+                                    "type": "boolean"
+                                  },
+                                  "analytics": {
+                                    "type": "boolean"
+                                  },
+                                  "settings": {
+                                    "type": "boolean"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "pathways": {
+                                    "type": "boolean"
+                                  },
+                                  "groups": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "number"
+                                    },
+                                    "nullable": true
+                                  }
+                                }
+                              }
+                            },
+                            "required": [
+                              "department_id",
+                              "permissions"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "team_member": {
+                    "id": 12345,
+                    "name": "John Doe",
+                    "email": "person@example.com",
+                    "department_permissions": [
+                      {
+                        "department_id": 34,
+                        "permissions": {
+                          "designs": true,
+                          "emails": true,
+                          "credential_attributes": true,
+                          "analytics": true,
+                          "settings": true,
+                          "role": "editor",
+                          "pathways": true,
+                          "groups": [
+                            1,
+                            2,
+                            3
+                          ]
+                        }
+                      },
+                      {
+                        "department_id": 35,
+                        "permissions": {
+                          "designs": false,
+                          "emails": false,
+                          "credential_attributes": false,
+                          "analytics": false,
+                          "settings": false,
+                          "role": "viewer",
+                          "pathways": false,
+                          "groups": null
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
           }
         },
         "summary": "Delete a Team Member",


### PR DESCRIPTION
## 🎟 Ticket
[HDR-5672](https://accredible.atlassian.net/browse/HDR-5672)

## 📝 What does this PR do?
Documents the new `pathways` boolean permission field across all Team Members public API endpoints, mirroring the backend changes in accredible/accredible-credential-api#4957.

Changes:
- Added `pathways` to Create, View, Update, and Delete response schemas and examples
- Added `pathways` to Create and Update request schemas and examples (with `default: false`)
- Updated all cURL samples to include the field
- Documented Update and Delete response bodies (previously `"content": {}`) since both render via `Api::V1::Public::TeamMemberSerializer`

## 🪙 Type of change
- [x] 📦 Chore/Documentation

## ✅ Checklist
- [x] PR title includes Jira ticket
- [x] At least 2 reviewers requested
- [x] Ready to squash and merge

[HDR-5672]: https://accredible.atlassian.net/browse/HDR-5672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ